### PR TITLE
Revisions of basement API.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,25 @@
+{
+  "pluginAlias": "ELPlatform",
+  "pluginType": "platform",
+  "singular": true,
+  "schema": {
+    "type":"object",
+    "properties": {
+      "enableRefreshSwitch": {
+	"type": "boolean",
+	"title": "Refresh button to discover devices",
+	"description": "Add a switch button accessory to re-discover devices",
+	"required": false,
+	"default": false
+      }
+    }
+  },
+  "layout": [
+    {
+      "title": "Common settings",
+      "items": [
+	"enableRefreshSwitch"
+      ]
+    }
+  ]
+}

--- a/lib/accessory-aircon.js
+++ b/lib/accessory-aircon.js
@@ -1,110 +1,191 @@
-module.exports = async (hap, accessory, el, address, eoj) => {
+module.exports = async (platform, accessory, el, address, eoj) => {
+  const hap = platform.api.hap
+  const log = platform.log
+  const context = accessory.context
   const service = accessory.getService(hap.Service.HeaterCooler) ||
                   accessory.addService(hap.Service.HeaterCooler)
+
+  context.Active ??= hap.Characteristic.Active.INACTIVE
+  context.CurrentHeaterCoolerState ??= hap.Characteristic.CurrentHeaterCoolerState.INACTIVE
+  context.TargetHeaterCoolerState ??= hap.Characteristic.TargetHeaterCoolerState.AUTO
+  context.CurrentTemperature ??= 25
+  context.CoolingThresholdTemperature ??= 30
+  context.HeatingThresholdTemperature ??= 16
+
+  platform.onNotifyHandler[`${address}${eoj.toString()}`] = (x) => {
+    log.debug(`${accessory.displayName}: ${JSON.stringify(x)}`)
+  }
 
   service.getCharacteristic(hap.Characteristic.Active)
   .on('set', async (value, callback) => {
     try {
-      await el.setPropertyValue(address, eoj, 0x80, {status: value != 0})
       callback()
+      await el.setPropertyValue(address, eoj, 0x80, {status: value != 0})
+      context.Active = value
     } catch (err) {
-      callback(err)
+      log.debug(`${accessory.displayName}: Failed to set Active. ${err}`)
     }
   })
   .on('get', async (callback) => {
     try {
+      callback(null, context.Active)
       const {status} = (await el.getPropertyValue(address, eoj, 0x80)).message.data
-      callback(null, status)
+      context.Active = status
+      service.updateCharacteristic(hap.Characteristic.Active, status)
     } catch (err) {
-      callback(err)
+      log.debug(`${accessory.displayName}: Failed to get Active. ${err}`)
     }
   })
 
   service.getCharacteristic(hap.Characteristic.CurrentHeaterCoolerState)
   .on('get', async (callback) => {
     try {
+      callback(null, context.CurrentHeaterCoolerState)
       const {status} = (await el.getPropertyValue(address, eoj, 0x80)).message.data
       if (!status) {
-        callback(null, hap.Characteristic.CurrentHeaterCoolerState.INACTIVE)
-        return
+        state = hap.Characteristic.CurrentHeaterCoolerState.INACTIVE
+      } else {
+	const compressor = (await el.getPropertyValue(address, eoj, 0xCD))?.message?.data?.compressor
+	if (compressor === false) {
+          state = hap.Characteristic.CurrentHeaterCoolerState.IDLE
+	} else {	// Maps AUTO to COOL
+	  const {mode} = (await el.getPropertyValue(address, eoj, 0xB0)).message.data
+	  state = mode === 3 ? hap.Characteristic.CurrentHeaterCoolerState.HEATING
+                             : hap.Characteristic.CurrentHeaterCoolerState.COOLING
+	}
       }
-      const {compressor} = (await el.getPropertyValue(address, eoj, 0xCD)).message.data
-      if (!compressor) {
-        callback(null, hap.Characteristic.CurrentHeaterCoolerState.IDLE)
-        return
-      }
-      const {mode} = (await el.getPropertyValue(address, eoj, 0xB0)).message.data
-      callback(null, mode === 2 ? hap.Characteristic.CurrentHeaterCoolerState.COOLING
-                                : hap.Characteristic.CurrentHeaterCoolerState.HEATING)
+      context.CurrentHeaterCoolerState = state
+      service.updateCharacteristic(hap.Characteristic.CurrentHeaterCoolerState, state)
     } catch (err) {
-      callback(null, hap.Characteristic.CurrentHeaterCoolerState.IDLE)
+      log.debug(`${accessory.displayName}: Failed to get CurrentHeaterCoolerState. ${err}`)
     }
   })
 
   service.getCharacteristic(hap.Characteristic.TargetHeaterCoolerState)
   .on('set', async (value, callback) => {
     try {
-      if (value !== hap.Characteristic.TargetHeaterCoolerState.OFF) {
+      callback()
+      // if (value !== hap.Characteristic.TargetHeaterCoolerState.OFF) {	// no such state
         let mode = 1
         if (value === hap.Characteristic.TargetHeaterCoolerState.COOL)
           mode = 2
         else if (value === hap.Characteristic.TargetHeaterCoolerState.HEAT)
           mode = 3
         await el.setPropertyValue(address, eoj, 0xB0, {mode})
-      } else {
-        await el.setPropertyValue(address, eoj, 0x80, {status: false})
-      }
-      callback()
+      // } else {
+      //   await el.setPropertyValue(address, eoj, 0x80, {status: false})
+      // }
     } catch (err) {
-      callback(err)
+      log.debug(`${accessory.displayName}: Failed to set TargetHeaterCoolerState. ${err}`)
     }
   })
   .on('get', async (callback) => {
     try {
-      let state = hap.Characteristic.TargetHeaterCoolerState.AUTO
-      const {status} = (await el.getPropertyValue(address, eoj, 0x80)).message.data
-      if (status) {
+      callback(null, context.TargetHeaterCoolerState)
+      let state = hap.Characteristic.TargetHeaterCoolerState.COOL
+      // const {status} = (await el.getPropertyValue(address, eoj, 0x80)).message.data
+      // if (status) {
         const {mode} = (await el.getPropertyValue(address, eoj, 0xB0)).message.data
-        if (mode === 2)
-          state = hap.Characteristic.TargetHeaterCoolerState.COOL
+        if (mode === 1)
+          state = hap.Characteristic.TargetHeaterCoolerState.AUTO
         else if (mode === 3)
           state = hap.Characteristic.TargetHeaterCoolerState.HEAT
-      } else {
-        state = hap.Characteristic.TargetHeaterCoolerState.OFF
-      }
-      callback(null, state)
+      // } else {
+      //   state = hap.Characteristic.TargetHeaterCoolerState.OFF	// no such state
+      // }
+      context.TargetHeaterCoolerState = state
+      service.updateCharacteristic(hap.Characteristic.TargetHeaterCoolerState, state)
     } catch (err) {
-      callback(err)
+      log.debug(`${accessory.displayName}: Failed to get TargetHeaterCoolerState. ${err}`)
     }
   })
 
-  const temperatureSetter = async (edt, value, callback) => {
-    try {
-      await el.setPropertyValue(address, eoj, edt, {temperature: parseInt(value)})
-      callback()
-    } catch (err) {
-      callback(err)
-    }
-  }
-  const temperatureGetter = async (edt, callback) => {
-    try {
-      const {temperature} = (await el.getPropertyValue(address, eoj, edt)).message.data
-      callback(null, temperature)
-    } catch (err) {
-      // Some air conditioners do not have temperature sensor, reporting error
-      // would make the accessory stop working.
-      callback(null, 0)
-    }
-  }
+  // const temperatureSetter = async (edt, value, callback) => {
+  //   try {
+  //     await el.setPropertyValue(address, eoj, edt, {temperature: parseInt(value)})
+  //     callback()
+  //   } catch (err) {
+  //     callback(err)
+  //   }
+  // }
+  // const temperatureGetter = async (edt, callback) => {
+  //   try {
+  //     const {temperature} = (await el.getPropertyValue(address, eoj, edt)).message.data
+  //     callback(null, temperature)
+  //   } catch (err) {
+  //     // Some air conditioners do not have temperature sensor, reporting error
+  //     // would make the accessory stop working.
+  //     callback(null, 0)
+  //   }
+  // }
+  // service.getCharacteristic(hap.Characteristic.CurrentTemperature)
+  // .setProps({minValue: -127, maxValue: 125, minStep: 1})
+  // .on('get', temperatureGetter.bind(null, 0xBB))
+  // service.getCharacteristic(hap.Characteristic.CoolingThresholdTemperature)
+  // .setProps({minValue: 16, maxValue: 30, minStep: 1})
+  // .on('set', temperatureSetter.bind(null, 0xB5))
+  // .on('get', temperatureGetter.bind(null, 0xB5))
+  // service.getCharacteristic(hap.Characteristic.HeatingThresholdTemperature)
+  // .setProps({minValue: 16, maxValue: 30, minStep: 1})
+  // .on('set', temperatureSetter.bind(null, 0xB6))
+  // .on('get', temperatureGetter.bind(null, 0xB6))
+
   service.getCharacteristic(hap.Characteristic.CurrentTemperature)
   .setProps({minValue: -127, maxValue: 125, minStep: 1})
-  .on('get', temperatureGetter.bind(null, 0xBB))
+  .on('get', async (callback) => {
+    try {
+      callback(null, context.CurrentTemperature)
+      const {temperature} = (await el.getPropertyValue(address, eoj, 0xBB)).message.data
+      context.CurrentTemperature = temperature
+      service.updateCharacteristic(hap.Characteristic.CurrentTemperature, temperature)
+    } catch (err) {
+      log.debug(`${accessory.displayName}: Failed to get CurrentTemperature. ${err}`)
+    }
+  })
+
   service.getCharacteristic(hap.Characteristic.CoolingThresholdTemperature)
   .setProps({minValue: 16, maxValue: 30, minStep: 1})
-  .on('set', temperatureSetter.bind(null, 0xB5))
-  .on('get', temperatureGetter.bind(null, 0xB5))
+  .on('set', async (value, callback) => {
+    try {
+      callback()
+      await el.setPropertyValue(address, eoj, 0xB5, {temperature: parseInt(value)})
+      context.CoolingThresholdTemperature = value
+    } catch (err) {
+      log.debug(`${accessory.displayName}: Failed to set CoolingThresholdTemperature. ${err}`)
+    }
+  })
+  .on('get', async (callback) => {
+    try {
+      callback(null, context.CoolingThresholdTemperature)
+      const {temperature} = (await el.getPropertyValue(address, eoj, 0xB5)).message.data
+      context.CoolingThresholdTemperature = temperature
+      service.updateCharacteristic(hap.Characteristic.CoolingThresholdTemperature, temperature)
+    } catch (err) {
+      log.debug(`${accessory.displayName}: Failed to get CoolingThresholdTemperature. ${err}`)
+    }
+  })
+
   service.getCharacteristic(hap.Characteristic.HeatingThresholdTemperature)
   .setProps({minValue: 16, maxValue: 30, minStep: 1})
-  .on('set', temperatureSetter.bind(null, 0xB6))
-  .on('get', temperatureGetter.bind(null, 0xB6))
+  .on('set', async (value, callback) => {
+    try {
+      callback()
+      await el.setPropertyValue(address, eoj, 0xB6, {temperature: parseInt(value)})
+      context.HeatingThresholdTemperature = value
+    } catch (err) {
+      log.debug(`${accessory.displayName}: Failed to set HeatingThresholdTemperature. ${err}`)
+    }
+  })
+  .on('get', async (callback) => {
+    try {
+      callback(null, context.HeatingThresholdTemperature)
+      const {temperature} = (await el.getPropertyValue(address, eoj, 0xB6)).message.data
+      context.HeatingThresholdTemperature = temperature
+      service.updateCharacteristic(hap.Characteristic.HeatingThresholdTemperature, temperature)
+    } catch (err) {
+      log.debug(`${accessory.displayName}: Failed to get HeatingThresholdTemperature. ${err}`)
+    }
+  })
+
+  return true
 }

--- a/lib/accessory-light.js
+++ b/lib/accessory-light.js
@@ -1,23 +1,29 @@
-module.exports = async (hap, accessory, el, address, eoj) => {
+module.exports = async (platform, accessory, el, address, eoj) => {
+  const hap = platform.api.hap
+  const context = accessory.context
   const service = accessory.getService(hap.Service.Lightbulb) ||
                   accessory.addService(hap.Service.Lightbulb)
 
+  context.status ??= false
+  context.Brightness ??= 100
+
   let {status} = (await el.getPropertyValue(address, eoj, 0x80)).message.data
+  context.status = status
   service.updateCharacteristic(hap.Characteristic.On, status)
 
   const updateStatus = (s) => {
-    status = s
+    context.status = s
     service.updateCharacteristic(hap.Characteristic.On, status)
   }
 
   service.getCharacteristic(hap.Characteristic.On)
   .on('set', (value, callback) => {
-    status = value
-    el.setPropertyValue(address, eoj, 0x80, {status})
+    context.status = value
+    el.setPropertyValue(address, eoj, 0x80, {context.status})
     callback()
   })
   .on('get', (callback) => {
-    callback(null, status)
+    callback(null, context.status)
     el.getPropertyValue(address, eoj, 0x80).then((res) => {
       if (res)
         updateStatus(res.message.data.status)
@@ -29,6 +35,7 @@ module.exports = async (hap, accessory, el, address, eoj) => {
     service.getCharacteristic(hap.Characteristic.Brightness)
     .on('set', async (value, callback) => {
       try {
+	context.Brightness = value
         await el.setPropertyValue(address, eoj, 0xB0, {level: value})
         callback()
       } catch (err) {
@@ -36,12 +43,13 @@ module.exports = async (hap, accessory, el, address, eoj) => {
       }
     })
     .on('get', async (callback) => {
-      if (!status) {
+      if (!context.status) {
         callback(null, 0)
         return
       }
       try {
         const res = await el.getPropertyValue(address, eoj, 0xB0)
+	context.Brightness = res.message.data.level
         callback(null, res.message.data.level)
       } catch (err) {
         callback(err)
@@ -50,21 +58,20 @@ module.exports = async (hap, accessory, el, address, eoj) => {
   }
 
   // Subscribe to status changes.
-  el.on('notify', (res) => {
-    if (!res)
-      return
-    const {seoj, prop} = res.message
-    if (res.device.address !== address ||
-        eoj[0] !== seoj[0] || eoj[1] !== seoj[1] || eoj[2] !== seoj[2])
-      return
+  platform.onNotifyHandler[`${address}${eoj.toString()}`] = (message) => {
+    const {seoj, prop} = message
 
     for (const p of prop) {
       if (!p.edt)
         continue
       if (p.epc === 0x80)  // status
         updateStatus(p.edt.status)
-      else if (p.epc === 0xB0)  // level
+      else if (p.epc === 0xB0) { // level
+	context.Brightness = p.edt.level
         service.updateCharacteristic(hap.Characteristic.Brightness, p.edt.level)
+      }
     }
-  })
+  }
+
+  return true
 }

--- a/lib/accessory.js
+++ b/lib/accessory.js
@@ -1,11 +1,9 @@
-module.exports = async (hap, accessory, el, address, eoj)  => {
+module.exports = async (platform, accessory, el, address, eoj)  => {
   if ((eoj[0] === 0x02 && eoj[1] === 0x90) ||
       (eoj[0] === 0x02 && eoj[1] === 0x91)) {
-    await require('./accessory-light')(hap, accessory, el, address, eoj)
-    return true
+    return await require('./accessory-light')(platform, accessory, el, address, eoj)
   } else if (eoj[0] === 0x01 && eoj[1] === 0x30) {
-    await require('./accessory-aircon')(hap, accessory, el, address, eoj)
-    return true
+    return await require('./accessory-aircon')(platform, accessory, el, address, eoj)
   }
   return false
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,20 +8,10 @@ const buildAccessory = require('./accessory')
 // Lazy-initialized.
 let Accessory, hap
 
-// Storage.
-let storagePath = null
-let storage = {accessories: {}}
-
 // Called by homebridge.
 module.exports = (homebridge) => {
   Accessory = homebridge.platformAccessory
   hap = homebridge.hap
-
-  // Read settings.
-  try {
-    storagePath = path.join(homebridge.user.storagePath(), 'persist', 'ELPlatform.json')
-    storage = JSON.parse(fs.readFileSync(storagePath))
-  } catch {}
 
   // Register the platform.
   homebridge.registerPlatform(packageJson.name, "ELPlatform", ELPlatform, true)
@@ -41,8 +31,9 @@ class ELPlatform {
 
     this.isDiscovering = false
     this.refreshSwitch = null
+    this.onNotifyHandler = {}
 
-    this.accessories = new Map
+    this.accessories = []
     this.api.once('didFinishLaunching', () => this._init())
   }
 
@@ -60,33 +51,37 @@ class ELPlatform {
     }
 
     // Save the accessory and build later.
-    this.accessories.set(accessory.UUID, accessory)
+    this.accessories.push(accessory)
   }
 
-  configurationRequestHandler(context, request, callback) {
-  }
+  // configurationRequestHandler(context, request, callback) {	// no such homebridge API
+  // }
 
   async _init() {
     await el.init()
     if (this.config.enableRefreshSwitch)
       await this._buildRefreshAccessory()
 
-    if (this.accessories.size === 0) {
+    if (this.accessories.length === 0) {
       // If there is no stored information (i.e. first time run) then do
       // discovery.
       await this._startDiscovery()
     } else {
       // Otherwise try to recover old accessories.
-      for (const [uuid, accessory] of this.accessories) {
-        const info = storage.accessories[accessory.UUID]
-        if (info) {
-          this._addAccesory(info.address, info.eoj, accessory.UUID)
-        } else {
-          this.accessories.delete(uuid)
-          this.api.unregisterPlatformAccessories(packageJson.name, "ELPlatform", [accessory])
-        }
+      for (const accessory of this.accessories) {
+	if (accessory.context.reachable === true) {
+	  accessory.context.reachable = false
+	  await this._addAccesory(accessory.context.address, accessory.context.eoj, accessory.UUID)
+	}
+	if (accessory.context.reachable === false) {	// _addAccesory needs to keep false if error
+	  this.api.unregisterPlatformAccessories(packageJson.name, "ELPlatform", [accessory])
+	}
       }
+      this.accessories = this.accessories.filter(x => x.context.reachable !== false)
     }
+    el.on('notify', async (x) => {
+      this.onNotifyHandler[`${x.device.address}${x.message.seoj.toString()}`]?.(x.message)
+    })
   }
 
   async _startDiscovery() {
@@ -94,8 +89,9 @@ class ELPlatform {
       return
 
     // Mark all as unreachable, the reachable ones will be updated later.
-    this.accessories.forEach((accessory, uuid) => {
-      accessory.updateReachability(false)
+    this.accessories.forEach(accessory => {
+      // accessory.updateReachability(false)	// deprecated API
+      accessory.context.reachable = false
     })
 
     return new Promise((resolve, reject) => {
@@ -115,7 +111,7 @@ class ELPlatform {
             continue
 
           let uid
-          try {
+          try {	// uid won't be unique if error
             uid = (await el.getPropertyValue(address, eoj, 0x83)).message.data.uid
           } catch {
             uid = address + '|' + JSON.stringify(eoj)
@@ -137,16 +133,13 @@ class ELPlatform {
       return
 
     // Removed unreachable accessories.
-    this.accessories.forEach((accessory, uuid) => {
-      if (!accessory.reachable) {
-        this.log(`Deleteing non-available accessory ${uuid}`)
-        this.accessories.delete(uuid)
+    this.accessories.forEach(accessory => {
+      if (!accessory.context.reachable) {
+        this.log(`Deleteing non-available accessory ${accessory.UUID}`)
         this.api.unregisterPlatformAccessories(packageJson.name, "ELPlatform", [accessory])
-
-        delete storage.accessories[uuid]
-        writeSettings(this)
       }
     })
+    this.accessories = this.accessories.filter(x => x.context.reachable !== false)
 
     // After stopping discovery, el would listen to broadcast.
     this.log('Finished discovery')
@@ -184,35 +177,25 @@ class ELPlatform {
   }
 
   async _addAccesory(address, eoj, uuid) {
-    const registered = this.accessories.has(uuid)
-    let accessory = registered ? this.accessories.get(uuid)
-                               : new Accessory(el.getClassName(eoj[0], eoj[1]), uuid)
+    const registered = this.accessories.find(x => x.UUID === uuid)
+    const accessory = registered ?? new Accessory(el.getClassName(eoj[0], eoj[1]), uuid)
 
-    // The _addAccesory may be called twice due to refreshing.
-    if (!accessory.alreadyBuilt) {
-      if (!await buildAccessory(hap, accessory, el, address, eoj))
+    // The _addAccesory may be called twice due to refreshing. 
+    if (accessory.context.reachable !== true) {
+      if (!await buildAccessory(this, accessory, el, address, eoj))
         return  // unsupported accessory
-      accessory.alreadyBuilt = true
-      accessory.once('identify', (paired, callback) => callback())
+      accessory.context.address = address
+      accessory.context.eoj = [...eoj]
+      accessory.context.reachable = true
+      // accessory.once('identify', (paired, callback) => callback())
     }
 
-    accessory.updateReachability(true)
+    // accessory.updateReachability(true)	// deprecated API
 
     if (!registered) {
       this.log(`Found new accessory: ${uuid}`)
-      this.accessories.set(uuid, accessory)
+      this.accessories.push(accessory)
       this.api.registerPlatformAccessories(packageJson.name, "ELPlatform", [accessory])
-
-      storage.accessories[uuid] = {address, eoj}
-      writeSettings(this)
     }
-  }
-}
-
-function writeSettings(platform) {
-  try {
-    fs.writeFileSync(storagePath, JSON.stringify(storage))
-  } catch (e) {
-    platform.log(`Failed to write settings: ${e}`)
   }
 }


### PR DESCRIPTION
This repository is configured very well (e.g. command queuing of echonet-lite) for further development, but basement homebridge API is a little bit old. This PR proposes to include recent homebridge changes. The use of external storage is removed as a result. The main advantage is accessory state persisting between re-starting. Platform level notification handling and experimental config.schema.json are also implemented.